### PR TITLE
feat: support s3 metadata for s3 event trigger

### DIFF
--- a/docs/src/content/docs/triggers/s3-event-trigger.md
+++ b/docs/src/content/docs/triggers/s3-event-trigger.md
@@ -104,6 +104,8 @@ All those information cannot be inferred from the S3 event alone, and to efficie
 
 <br>
 
+The S3 event trigger middleware also converts S3 native metadata to Lakechain custom [Metadata](/project-lakechain/general/events/#-metadata), so you can add any information regarding the uploaded Object to the CloudEvent and then to the chain.
+
 ---
 
 ### 📤 Events


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Adding S3 metadata to `s3-event-trigger` middleware to initialise `custom` metadata with the one specified in S3.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
