### PR TITLE
fix: include condition mod for pdf-vision-pipeline build

### DIFF
--- a/examples/simple-pipelines/pdf-vision-pipeline/package.json
+++ b/examples/simple-pipelines/pdf-vision-pipeline/package.json
@@ -36,7 +36,8 @@
     "@project-lakechain/sharp-image-transform": "*",
     "@project-lakechain/reducer": "*",
     "@project-lakechain/transform": "*",
-    "@project-lakechain/s3-storage-connector": "*"
+    "@project-lakechain/s3-storage-connector": "*",
+    "@project-lakechain/condition": "*"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.147.1",


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Added `@project-lakechain/condition` to package deps as otherwise the `npm run build-pkg` fails:

```
   ✖  pdf-vision-pipeline:build
      > pdf-vision-pipeline@0.7.0 build
      > npx tsc
      
      stack.ts(28,39): error TS2307: Cannot find module '@project-lakechain/condition' or its corresponding type declarations.
      npm ERR! Lifecycle script `build` failed with error: 
      npm ERR! Error: command failed 
      npm ERR!   in workspace: pdf-vision-pipeline@0.7.0 
      npm ERR!   at location: /<redacted>/project-lakechain/examples/simple-pipelines/pdf-vision-pipeline 
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
