### PR TITLE
feat(examples): added audio combination pipeline

### DIFF
--- a/examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline/README.md
+++ b/examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline/README.md
@@ -1,0 +1,81 @@
+# 🎥 Audio Combination Pipeline
+
+> This example showcases how to ingest add multiple audio tracks to one video using ffmpeg on AWS.
+
+## :dna: Pipeline
+
+```mermaid
+flowchart LR
+  Files([Video, Audio Tracks, Metadata]) -.-> Input([ZIP Archive])
+  Input -.-> Trigger[S3 Trigger]
+  Trigger -. ZIP Archive .-> ArchiveProcessor[ZIP Processor]
+  ArchiveProcessor -. File .-> Reducer[Reducer]
+  ArchiveProcessor -. File .-> Reducer
+  ArchiveProcessor -. File .-> Reducer
+  Reducer -. Composite Event .-> FFMPEG[FFMPEG Processor]
+  FFMPEG -. Video .-> S3[S3 Storage Connector]
+  S3 -.-> Bucket[S3 Bucket]
+```
+
+## ❓ What is Happening
+
+In this pipeline, we demonstrate how to add multiple audio tracks to a video with the ffmpeg middleware by using composite events.
+
+1. The pipeline starts by ingesting a ZIP archive containing the video, audio tracks, as well as a metadata file.
+2. The ZIP archive is processed by the `ZIP Processor` middleware, which extracts the files and sends them to the `Reducer` middleware.
+3. The `Reducer` middleware combines the files into a single event that is sent to the `FFMPEG Processor`.
+4. The `FFMPEG Processor` middleware uses the ffmpeg command to combine the audio tracks with the video.
+5. The generated video is then uploaded to an S3 bucket.
+
+Using this pipeline, you can streamline the process of creating questions to test your knowledge about the content of various documents, including videos, podcasts, scientific papers, etc. without your data leaving AWS.
+
+## 🗒️ How to Use
+
+1. Deploy the pipeline using the instructions below.
+This will create the necessary resources in your AWS account and output the source and destination S3 buckets.
+2. Create a JSON metadata file with the following structure:
+```json
+{
+  "video": "video_name.mp4",
+  "tracks": ["track1_name.mp3", "track2_name.mp3"]
+}
+```
+> ⚠️ The extensions of the files determine the type of file they are, so ensure they are correct. The file formats supported are any of the video and audio files [compatible with ffmpeg](https://ffmpeg.org/ffmpeg-formats.html#Demuxers).
+3. Create a ZIP archive that contains the video, audio tracks, and the metadata file.
+4. Upload the ZIP archive to the S3 source bucket. For example, you can use the AWS CLI as described [here](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html#examples).
+5. The pipeline will automatically process the ZIP archive and add the generated video to the destination bucket.
+6. You can download the generated video from the destination bucket and view it to see the audio tracks combined with the video.
+> ⚠️ Known limitation: The output will be as long as the longest input file.
+
+## 📝 Requirements
+
+The following requirements are needed to deploy the infrastructure associated with this pipeline:
+
+- You need access to a development AWS account.
+- [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html#getting_started_install) is required to deploy the infrastructure.
+- [Docker](https://docs.docker.com/get-docker/) is required to be running to build middlewares.
+- [Node.js](https://nodejs.org/en/download/) v18+ and NPM.
+- [Python](https://www.python.org/downloads/) v3.8+ and [Pip](https://pip.pypa.io/en/stable/installation/).
+
+## 🚀 Deploy
+
+Head to the directory [`examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline`](/examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline) in the repository and run the following commands to build the example:
+
+```bash
+npm install
+npm run build-pkg
+```
+
+You can then deploy the example to your account (ensure the AWS CDK is installed and is configured with the appropriate AWS credentials and AWS region):
+
+```bash
+npm run deploy
+```
+
+## 🧹 Clean up
+
+Don't forget to clean up the resources created by this example by running the following command:
+
+```bash
+npm run destroy
+```

--- a/examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline/cdk.json
+++ b/examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline/cdk.json
@@ -1,0 +1,39 @@
+{
+  "app": "npx ts-node --prefer-ts-exts stack.ts",
+  "watch": {
+    "include": ["**"],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test",
+      "**/*.zip"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/core:stackRelativeExports": true,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/core:target-partitions": ["aws", "aws-cn"]
+  }
+}

--- a/examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline/package.json
+++ b/examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "audio-combination-pipeline",
+  "description": "An example showcasing how to use FFMPEG to add multiple audio tracks to a video.",
+  "version": "0.7.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "build-pkg": "npx lerna run build --scope=audio-combination-pipeline --include-dependencies",
+    "clean": "npx rimraf dist/ cdk.out/ node_modules/",
+    "audit": "npm audit && npm run synth --silent | cfn_nag",
+    "lint": "npx eslint .",
+    "synth": "npx --yes cdk synth",
+    "deploy": "npx --yes cdk deploy",
+    "hotswap": "npx --yes cdk deploy --hotswap",
+    "destroy": "npx --yes cdk destroy --all"
+  },
+  "author": {
+    "name": "Raphael Le Goaller",
+    "email": "raphael@rlglr.fr"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/awslabs/project-lakechain"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^20.8.10",
+    "esbuild": "0.21.5",
+    "ts-jest": "^29.2.3",
+    "ts-node": "^10.9.2"
+  },
+  "dependencies": {
+    "@project-lakechain/s3-event-trigger": "*",
+    "@project-lakechain/ffmpeg-processor": "*",
+    "@project-lakechain/transcribe-audio-processor": "*",
+    "@project-lakechain/s3-storage-connector": "*",
+    "@project-lakechain/zip-processor": "*",
+    "@project-lakechain/reducer": "*"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "2.150.0",
+    "constructs": "^10.3.0"
+  }
+}

--- a/examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline/stack.ts
+++ b/examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline/stack.ts
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with therg  License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+
+import { Construct } from 'constructs';
+import { CacheStorage } from '@project-lakechain/core';
+import { S3EventTrigger } from '@project-lakechain/s3-event-trigger';
+import { S3StorageConnector } from '@project-lakechain/s3-storage-connector';
+
+import { ZipInflateProcessor } from '@project-lakechain/zip-processor';
+import { FfmpegProcessor, CloudEvent, FfmpegUtils, Ffmpeg } from '@project-lakechain/ffmpeg-processor';
+import { Reducer, TimeWindowStrategy } from '@project-lakechain/reducer';
+
+const VIDEO_MIME_TYPE = 'video/';
+const AUDIO_MIME_TYPE = 'audio/';
+
+/**
+ * This intent is a function that will get executed in the cloud
+ * by the FFMPEG middleware. It takes a video input, multiple
+ * audio inputs and combines them into a single video file.
+ * the audio from it.
+ * @param events the events to process.
+ * @param ffmpeg the FFMPEG instance.
+ * @param utils a set of utilities to interact with the FFMPEG
+ * middleware.
+ * @returns the FFMPEG chain.
+ */
+const intent = async (events: CloudEvent[], ffmpeg: Ffmpeg, utils: FfmpegUtils) => {
+  const fileType = (event: CloudEvent) => {
+    return {
+      isVideo: event.data().document().mimeType().startsWith(VIDEO_MIME_TYPE),
+      isAudio: event.data().document().mimeType().startsWith(AUDIO_MIME_TYPE)
+    };
+  };
+
+  // Extract and parse the metadata from the json file.
+  const metadataFile = events
+    .filter((event) => event.data().document().filename().extension() === '.json')[0]
+    .data()
+    .document()
+    .data();
+  const metadataBuffer = (await metadataFile.asBuffer()).toString('utf-8');
+  const metadata: { video: string; tracks: string[] } = JSON.parse(metadataBuffer);
+
+  if (metadata.video.length === 0 || !(Array.isArray(metadata.tracks) && metadata.tracks.length > 0)) {
+    throw new Error('The metadata file is not valid');
+  }
+
+  // Get the video and audio files.
+  const video = events.find(
+    (event) => metadata.video === event.data().document().filename().basename() && fileType(event).isVideo
+  );
+  const tracks = events.filter(
+    (event) =>
+      metadata.tracks.includes(event.data().document().filename().basename()) && fileType(event).isAudio
+  );
+
+  if (video === undefined || tracks.length !== metadata.tracks.length) {
+    throw new Error('The files received do not match the metadata');
+  }
+
+  // Add the video and audio inputs to the FFMPEG chain.
+  let ffmpegInstance = ffmpeg().input(utils.file(video));
+  for (const track of tracks) {
+    ffmpegInstance = ffmpegInstance.input(utils.file(track));
+  }
+
+  // Map the tracks to the output.
+  const ffmpegGeneratedOptions = tracks.map((_, i) => `-map ${i + 1}:a`);
+
+  // Return the FFMPEG chain.
+  return ffmpegInstance
+    .addOption('-map 0')
+    .addOptions(ffmpegGeneratedOptions)
+    .addOption('-c:v copy')
+    .save('output.mp4');
+};
+
+/**
+ * An example stack showcasing how to use Project Lakechain
+ * to add multiple audio tracks to a video using the FFMPEG
+ * processor.
+ *
+ * The pipeline looks as follows:
+ *
+ * ┌──────────────┐   ┌─────────────────┐   ┌───────────────────┐   ┌─────────────┐
+ * │   S3 Input   ├──►│  ZIP Processor  ├──►│  FFMPEG Processor ├──►│  S3 Output  │
+ * └──────────────┘   └─────────────────┘   └───────────────────┘   └─────────────┘
+ *
+ */
+export class AudioCombinationPipeline extends cdk.Stack {
+  /**
+   * Stack constructor.
+   */
+  constructor(scope: Construct, id: string, env: cdk.StackProps) {
+    super(scope, id, {
+      description: 'A pipeline using FFMPEG to add multiple audio tracks to a video.',
+      ...env
+    });
+
+    // The VPC in which the FFMPEG processor will be deployed.
+    const vpc = this.createVpc('Vpc');
+
+    ///////////////////////////////////////////
+    ///////         S3 Storage          ///////
+    ///////////////////////////////////////////
+
+    // The source bucket.
+    const source = new s3.Bucket(this, 'Bucket', {
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      autoDeleteObjects: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      enforceSSL: true
+    });
+
+    // The destination bucket.
+    const destination = new s3.Bucket(this, 'Destination', {
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      autoDeleteObjects: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      enforceSSL: true
+    });
+
+    // The cache storage.
+    const cache = new CacheStorage(this, 'Cache', {});
+
+    ///////////////////////////////////////////
+    ///////     Lakechain Pipeline      ///////
+    ///////////////////////////////////////////
+
+    // Create the S3 trigger monitoring the bucket
+    // for uploaded objects.
+    const trigger = new S3EventTrigger.Builder()
+      .withScope(this)
+      .withIdentifier('Trigger')
+      .withCacheStorage(cache)
+      .withBucket(source)
+      .build();
+
+    const zipProcessor = new ZipInflateProcessor.Builder()
+      .withScope(this)
+      .withIdentifier('ZipProcessor')
+      .withCacheStorage(cache)
+      .withSource(trigger)
+      .build();
+
+    const reducer = new Reducer.Builder()
+      .withScope(this)
+      .withIdentifier('Reducer')
+      .withCacheStorage(cache)
+      .withSource(zipProcessor)
+      .withReducerStrategy(
+        new TimeWindowStrategy.Builder()
+          .withTimeWindow(cdk.Duration.seconds(15))
+          .withJitter(cdk.Duration.seconds(5))
+          .build()
+      )
+      .build();
+
+    const ffmpeg = new FfmpegProcessor.Builder()
+      .withScope(this)
+      .withIdentifier('FfmpegProcessor')
+      .withCacheStorage(cache)
+      .withVpc(vpc)
+      .withIntent(intent)
+      .withSource(reducer)
+      .build();
+
+    new S3StorageConnector.Builder()
+      .withScope(this)
+      .withIdentifier('Storage')
+      .withCacheStorage(cache)
+      .withDestinationBucket(destination)
+      .withSource(ffmpeg)
+      .build();
+
+    // Display the source bucket information in the console.
+    new cdk.CfnOutput(this, 'SourceBucketName', {
+      description: 'The name of the source bucket.',
+      value: source.bucketName
+    });
+
+    // Display the destination bucket information in the console.
+    new cdk.CfnOutput(this, 'DestinationBucketName', {
+      description: 'The name of the destination bucket.',
+      value: destination.bucketName
+    });
+  }
+
+  /**
+   * @param id the VPC identifier.
+   * @returns a new VPC with a public, private and isolated
+   * subnets for the pipeline.
+   */
+  private createVpc(id: string): ec2.IVpc {
+    return new ec2.Vpc(this, id, {
+      enableDnsSupport: true,
+      enableDnsHostnames: true,
+      ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/20'),
+      maxAzs: 1,
+      subnetConfiguration: [
+        {
+          // Used by NAT Gateways to provide Internet access
+          // to the containers.
+          name: 'public',
+          subnetType: ec2.SubnetType.PUBLIC,
+          cidrMask: 28
+        },
+        {
+          // Used by the containers.
+          name: 'private',
+          subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+          cidrMask: 24
+        },
+        {
+          // Used by EFS.
+          name: 'isolated',
+          subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+          cidrMask: 28
+        }
+      ]
+    });
+  }
+}
+
+// Creating the CDK application.
+const app = new cdk.App();
+
+// Environment variables.
+const account = process.env.CDK_DEFAULT_ACCOUNT ?? process.env.AWS_DEFAULT_ACCOUNT;
+const region = process.env.CDK_DEFAULT_REGION ?? process.env.AWS_DEFAULT_REGION;
+
+// Deploy the stack.
+new AudioCombinationPipeline(app, 'AudioCombinationPipeline', {
+  env: {
+    account,
+    region
+  }
+});

--- a/examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline/tsconfig.json
+++ b/examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["./*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1338,6 +1338,28 @@
         "constructs": "^10.3.0"
       }
     },
+    "examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline": {
+      "version": "0.7.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@project-lakechain/ffmpeg-processor": "*",
+        "@project-lakechain/reducer": "*",
+        "@project-lakechain/s3-event-trigger": "*",
+        "@project-lakechain/s3-storage-connector": "*",
+        "@project-lakechain/transcribe-audio-processor": "*",
+        "@project-lakechain/zip-processor": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.8.10",
+        "esbuild": "0.21.5",
+        "ts-jest": "^29.2.3",
+        "ts-node": "^10.9.2"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "2.150.0",
+        "constructs": "^10.3.0"
+      }
+    },
     "examples/simple-pipelines/video-processing-pipelines/audio-extraction-pipeline": {
       "version": "0.7.0",
       "license": "Apache-2.0",
@@ -10925,6 +10947,10 @@
       "integrity": "sha512-EFGCRj4kLX1dHv1cDzTk+xbjBFj1GnJDpui52YmEcxxHHEWjYyT6l51U7n6WQ28osZH4S9gSybxe56Vm7vB61Q==",
       "license": "MIT"
     },
+    "node_modules/audio-combination-pipeline": {
+      "resolved": "examples/simple-pipelines/video-processing-pipelines/audio-combination-pipeline",
+      "link": true
+    },
     "node_modules/audio-extraction-pipeline": {
       "resolved": "examples/simple-pipelines/video-processing-pipelines/audio-extraction-pipeline",
       "link": true
@@ -10950,7 +10976,6 @@
         "yaml",
         "mime-types"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
@@ -26580,7 +26605,6 @@
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.3.tgz",
       "integrity": "sha512-yCcfVdiBFngVz9/keHin9EnsrQtQtEu3nRykNy9RVp+FiPFFbPJ3Sg6Qg4+TkmH0vMP5qsTKgXSsk80HRwvdgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bs-logger": "0.x",
         "ejs": "^3.1.10",


### PR DESCRIPTION
## Description of changes:

Adds a simple example pipeline that shows how to add an arbitrary amount of audio tracks to a video. It works by passing a composite event with all the required inputs to the ffmpeg middleware.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
