### PR TITLE
feat(examples): added document quiz pipeline

### DIFF
--- a/examples/simple-pipelines/document-quiz-pipeline/README.md
+++ b/examples/simple-pipelines/document-quiz-pipeline/README.md
@@ -1,0 +1,70 @@
+# 🎥 Document Quiz Pipeline
+
+> This example shows how to easily implement a pipeline that generates a list of questions from an arbitrary file, such as text documents (including PDF), audio, or video files, using LakeChain and Amazon Bedrock.
+
+> You can use these questions, for example, to test your knowledge about the content of various documents, such as videos, podcasts, or scientific papers, etc.
+
+## :dna: Pipeline
+
+```mermaid
+flowchart LR
+  Input([Documents]) -.-> Trigger[S3 Trigger]
+  Trigger -. Text .-> Anthropic[Anthropic Text Processor]
+  Trigger -. PDF .-> PDF[PDF Processor]
+  PDF -. Text .-> Anthropic
+  Trigger -. Audio .-> Transcribe[Transcribe Audio Processor]
+  Trigger -. Video .-> FFMPEG[FFMPEG Processor]
+  FFMPEG -. Audio .-> Transcribe
+  Transcribe -. VTT .-> Anthropic
+  Anthropic -. JSON .-> S3[S3 Storage Connector]
+  S3 -.-> Bucket[S3 Bucket]
+```
+
+## ❓ What is Happening
+
+1. The pipeline starts when a document is uploaded to the source `S3` bucket.
+2. The pipeline selects the appropriate processor(s) for the file, depending on its filetype. It extracts the associated text.
+3. The `Text Processor` generates questions from the extracted text using the Anthropic [Claude v3 Sonnet](https://aws.amazon.com/fr/about-aws/whats-new/2024/03/anthropics-claude-3-sonnet-model-amazon-bedrock/) model hosted on Amazon Bedrock.
+4. The generated questions are then added to a JSON file in the destination bucket, with the following format:
+```json
+{
+  "questions": [
+    "What is ...?",
+    "Why is ...?",
+    "How ...?"
+  ]
+}
+```
+
+## 📝 Requirements
+
+The following requirements are needed to deploy the infrastructure associated with this pipeline:
+
+- You need access to a development AWS account.
+- [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html#getting_started_install) is required to deploy the infrastructure.
+- [Docker](https://docs.docker.com/get-docker/) is required to be running to build middlewares.
+- [Node.js](https://nodejs.org/en/download/) v18+ and NPM.
+- [Python](https://www.python.org/downloads/) v3.8+ and [Pip](https://pip.pypa.io/en/stable/installation/).
+
+## 🚀 Deploy
+
+Head to the directory [`examples/simple-pipelines/document-quiz-pipeline`](/examples/simple-pipelines/document-quiz-pipeline) in the repository and run the following commands to build the example:
+
+```bash
+npm install
+npm run build-pkg
+```
+
+You can then deploy the example to your account (ensure the AWS CDK is installed and is configured with the appropriate AWS credentials and AWS region):
+
+```bash
+npm run deploy
+```
+
+## 🧹 Clean up
+
+Don't forget to clean up the resources created by this example by running the following command:
+
+```bash
+npm run destroy
+```

--- a/examples/simple-pipelines/document-quiz-pipeline/cdk.json
+++ b/examples/simple-pipelines/document-quiz-pipeline/cdk.json
@@ -1,0 +1,39 @@
+{
+  "app": "npx ts-node --prefer-ts-exts stack.ts",
+  "watch": {
+    "include": ["**"],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test",
+      "**/*.zip"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/core:stackRelativeExports": true,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/core:target-partitions": ["aws", "aws-cn"]
+  }
+}

--- a/examples/simple-pipelines/document-quiz-pipeline/package.json
+++ b/examples/simple-pipelines/document-quiz-pipeline/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "document-quiz-pipeline",
+  "description": "Builds a pipeline that generates questions for ingested documents.",
+  "version": "0.7.0",
+  "private": true,
+  "scripts": {
+    "build": "npx tsc",
+    "build-pkg": "npx lerna run build --scope=document-quiz-pipeline --include-dependencies",
+    "clean": "npx rimraf dist/ cdk.out/ node_modules/",
+    "audit": "npm audit && npm run synth --silent | cfn_nag",
+    "lint": "npx eslint .",
+    "synth": "npx --yes cdk synth",
+    "deploy": "npx --yes cdk deploy",
+    "hotswap": "npx --yes cdk deploy --hotswap",
+    "destroy": "npx --yes cdk destroy --all"
+  },
+  "author": {
+    "name": "Raphael Le Goaller",
+    "email": "raphael@rlglr.fr"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/awslabs/project-lakechain"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^20.8.10",
+    "esbuild": "0.21.5",
+    "ts-jest": "^29.2.3",
+    "ts-node": "^10.9.2"
+  },
+  "dependencies": {
+    "@project-lakechain/s3-event-trigger": "*",
+    "@project-lakechain/ffmpeg-processor": "*",
+    "@project-lakechain/transcribe-audio-processor": "*",
+    "@project-lakechain/pdf-text-converter": "*",
+    "@project-lakechain/bedrock-text-processors": "*",
+    "@project-lakechain/s3-storage-connector": "*"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "2.150.0",
+    "constructs": "^10.3.0"
+  }
+}

--- a/examples/simple-pipelines/document-quiz-pipeline/prompt.txt
+++ b/examples/simple-pipelines/document-quiz-pipeline/prompt.txt
@@ -1,0 +1,13 @@
+Follow carefully the instructions below to generate a set of questions about the document provided.
+- There should be at least 3 questions and no more than 5-10 questions.
+- Questions must be about general information in the document, not specific details, but they should only be answerable by someone who has a good understanding of the subject.
+- Questions must be in the same order as the content they are about appears in the document.
+- Questions must not contain any special characters, only letters, numbers, spaces, and punctuation.
+- Make sure that the questions are not answered by a later question or a yes/no answer.
+- You must output a valid JSON document and nothing else.
+- Do not provide any additional information other than the JSON document; no preamble or introduction.
+- The text within the JSON values must not include line breaks.
+The structure of the JSON document should be as follows.
+{
+  "questions": ["A question about the document?", "A second question about the document?"]
+}

--- a/examples/simple-pipelines/document-quiz-pipeline/stack.ts
+++ b/examples/simple-pipelines/document-quiz-pipeline/stack.ts
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+
+import { Construct } from 'constructs';
+import { CacheStorage } from '@project-lakechain/core';
+
+import { S3EventTrigger } from '@project-lakechain/s3-event-trigger';
+import { S3StorageConnector } from '@project-lakechain/s3-storage-connector';
+
+import { FfmpegProcessor, CloudEvent, FfmpegUtils, Ffmpeg } from '@project-lakechain/ffmpeg-processor';
+import { TranscribeAudioProcessor } from '@project-lakechain/transcribe-audio-processor';
+import { PdfTextConverter } from '@project-lakechain/pdf-text-converter';
+import { AnthropicTextProcessor, AnthropicTextModel } from '@project-lakechain/bedrock-text-processors';
+
+/**
+ * This is the prompt passed to the model to generate the questions.
+ */
+const prompt = fs.readFileSync(path.join(__dirname, 'prompt.txt'), 'utf-8');
+
+/**
+ * This intent is a function that will get executed in the cloud
+ * by the FFMPEG middleware. It takes a video input and extracts
+ * the audio from it.
+ * @param events the events to process, in this case there will
+ * be only one event, as video files are processed sequentially.
+ * @param ffmpeg the FFMPEG instance.
+ * @param utils a set of utilities to interact with the FFMPEG
+ * middleware.
+ * @returns the FFMPEG chain.
+ */
+const intent = async (events: CloudEvent[], ffmpeg: Ffmpeg, utils: FfmpegUtils) => {
+  return ffmpeg().input(utils.file(events[0])).noVideo().save('output.mp3');
+};
+
+/**
+ * An example showcasing how to use Lakechain
+ * to take any text, pdf, audio, or video document
+ * and create corresponding questions using
+ * Amazon Bedrock.
+ */
+export class DocumentQuizStack extends cdk.Stack {
+  /**
+   * Stack constructor.
+   */
+  constructor(scope: Construct, id: string, env: cdk.StackProps) {
+    super(scope, id, {
+      description: 'A pipeline creating quizes for documents using Amazon Bedrock.',
+      ...env
+    });
+
+    // The VPC in which the FFMPEG processor will be deployed.
+    const vpc = this.createVpc('Vpc');
+
+    ///////////////////////////////////////////
+    ///////         S3 Storage          ///////
+    ///////////////////////////////////////////
+
+    // The source bucket.
+    const source = new s3.Bucket(this, 'Bucket', {
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      autoDeleteObjects: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      enforceSSL: true
+    });
+
+    // The destination bucket.
+    const destination = new s3.Bucket(this, 'Destination', {
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      autoDeleteObjects: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      enforceSSL: true
+    });
+
+    // The cache storage.
+    const cache = new CacheStorage(this, 'Cache', {});
+
+    ///////////////////////////////////////////
+    ///////     Lakechain Pipeline      ///////
+    ///////////////////////////////////////////
+
+    // Create the S3 trigger monitoring the bucket
+    // for uploaded objects.
+    const trigger = new S3EventTrigger.Builder()
+      .withScope(this)
+      .withIdentifier('Trigger')
+      .withCacheStorage(cache)
+      .withBucket(source)
+      .build();
+
+    // We are using the FFMPEG processor to extract audio from videos.
+    const ffmpegProcessor = new FfmpegProcessor.Builder()
+      .withScope(this)
+      .withIdentifier('FfmpegProcessor')
+      .withCacheStorage(cache)
+      .withVpc(vpc)
+      .withIntent(intent)
+      .withSource(trigger)
+      .build();
+
+    // We are using the `TranscribeAudioProcessor` component to transcribe
+    // audio into a VTT file.
+    // Technically, this component can be used only transcribe audio files
+    // in the MP3, MP4, WAV, FLAC, AMR, OGG, and WebM formats.
+    const transcribeProcessor = new TranscribeAudioProcessor.Builder()
+      .withScope(this)
+      .withIdentifier('TranscribeTextProcessor')
+      .withCacheStorage(cache)
+      .withOutputFormats('vtt')
+      .withSources([trigger, ffmpegProcessor])
+      .build();
+
+    // We are using the `PdfTextConverter` component to extract text
+    // from PDF files.
+    const pdfTextConverter = new PdfTextConverter.Builder()
+      .withScope(this)
+      .withIdentifier('PdfTextConverter')
+      .withCacheStorage(cache)
+      .withSource(trigger)
+      .build();
+
+    // We are using the `AnthropicTextProcessor` component to generate
+    // the questions for the documents.
+    // The assistant prefill allows to guide the model in generating
+    // a JSON document with no preamble.
+    const anthropicTextProcessor = new AnthropicTextProcessor.Builder()
+      .withScope(this)
+      .withIdentifier('AnthropicTextProcessor')
+      .withCacheStorage(cache)
+      .withRegion('eu-central-1')
+      .withModel(AnthropicTextModel.ANTHROPIC_CLAUDE_V3_SONNET)
+      .withPrompt(prompt)
+      .withAssistantPrefill('{')
+      .withModelParameters({
+        temperature: 0.5,
+        max_tokens: 4096
+      })
+      .withSources([trigger, transcribeProcessor, pdfTextConverter])
+      .build();
+
+    new S3StorageConnector.Builder()
+      .withScope(this)
+      .withIdentifier('S3StorageConnector')
+      .withCacheStorage(cache)
+      .withDestinationBucket(destination)
+      .withSource(anthropicTextProcessor)
+      .build();
+
+    // Display the source bucket information in the console.
+    new cdk.CfnOutput(this, 'SourceBucketName', {
+      description: 'The name of the source bucket.',
+      value: source.bucketName
+    });
+
+    // Display the destination bucket information in the console.
+    new cdk.CfnOutput(this, 'DestinationBucketName', {
+      description: 'The name of the destination bucket.',
+      value: destination.bucketName
+    });
+  }
+
+  /**
+   * @param id the VPC identifier.
+   * @returns a new VPC with a public, private and isolated
+   * subnets for the pipeline.
+   */
+  private createVpc(id: string): ec2.IVpc {
+    return new ec2.Vpc(this, id, {
+      enableDnsSupport: true,
+      enableDnsHostnames: true,
+      ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/20'),
+      maxAzs: 1,
+      subnetConfiguration: [
+        {
+          // Used by NAT Gateways to provide Internet access
+          // to the containers.
+          name: 'public',
+          subnetType: ec2.SubnetType.PUBLIC,
+          cidrMask: 28
+        },
+        {
+          // Used by the containers.
+          name: 'private',
+          subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+          cidrMask: 24
+        },
+        {
+          // Used by EFS.
+          name: 'isolated',
+          subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+          cidrMask: 28
+        }
+      ]
+    });
+  }
+}
+
+// Creating the CDK application.
+const app = new cdk.App();
+
+// Environment variables.
+const account = process.env.CDK_DEFAULT_ACCOUNT ?? process.env.AWS_DEFAULT_ACCOUNT;
+const region = process.env.CDK_DEFAULT_REGION ?? process.env.AWS_DEFAULT_REGION;
+
+// Deploy the stack.
+new DocumentQuizStack(app, 'DocumentQuizStack', {
+  env: {
+    account,
+    region
+  }
+});

--- a/examples/simple-pipelines/document-quiz-pipeline/tsconfig.json
+++ b/examples/simple-pipelines/document-quiz-pipeline/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["./*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -258,6 +258,28 @@
         "constructs": "^10.3.0"
       }
     },
+    "examples/simple-pipelines/document-quiz-pipeline": {
+      "version": "0.7.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@project-lakechain/bedrock-text-processors": "*",
+        "@project-lakechain/ffmpeg-processor": "*",
+        "@project-lakechain/pdf-text-converter": "*",
+        "@project-lakechain/s3-event-trigger": "*",
+        "@project-lakechain/s3-storage-connector": "*",
+        "@project-lakechain/transcribe-audio-processor": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.8.10",
+        "esbuild": "0.21.5",
+        "ts-jest": "^29.2.3",
+        "ts-node": "^10.9.2"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "2.150.0",
+        "constructs": "^10.3.0"
+      }
+    },
     "examples/simple-pipelines/email-nlp-pipeline": {
       "version": "0.7.0",
       "license": "Apache-2.0",
@@ -10950,7 +10972,6 @@
         "yaml",
         "mime-types"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
@@ -15102,6 +15123,10 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/document-quiz-pipeline": {
+      "resolved": "examples/simple-pipelines/document-quiz-pipeline",
+      "link": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -26580,7 +26605,6 @@
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.3.tgz",
       "integrity": "sha512-yCcfVdiBFngVz9/keHin9EnsrQtQtEu3nRykNy9RVp+FiPFFbPJ3Sg6Qg4+TkmH0vMP5qsTKgXSsk80HRwvdgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bs-logger": "0.x",
         "ejs": "^3.1.10",


### PR DESCRIPTION
## Description of changes:

Adds a simple example pipeline that generates a list of questions from an arbitrary file that is in one of the following formats: plaintext, PDF, audio, or video (with an audio track).

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
